### PR TITLE
Updated to version 4.1.0 and added a new class for installing language packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # Libreoffice Puppet Module for Boxen
 
-[![Build Status](https://travis-ci.org/boxen/puppet-libreoffice.png?branch=master)](https://travis-ci.org/boxen/puppet-libreoffice)
+[![Build Status](https://travis-ci.org/magicmonty/puppet-libreoffice.png?branch=master)](https://travis-ci.org/magicmonty/puppet-libreoffice)
 
 ## Usage
 
 ```puppet
 include libreoffice
+
+## default language is 'de'
+include libreoffice::languagepack
+
+## or set your own locale
+class { 'libreoffice::languagepack':
+  locale => 'de'
+}
 ```
 
 ## Required Puppet Modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Libreoffice Puppet Module for Boxen
 
-[![Build Status](https://travis-ci.org/magicmonty/puppet-libreoffice.png?branch=master)](https://travis-ci.org/magicmonty/puppet-libreoffice)
+[![Build Status](https://travis-ci.org/boxen/puppet-libreoffice.png?branch=master)](https://travis-ci.org/boxen/puppet-libreoffice)
 
 ## Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class libreoffice {
   package { 'LibreOffice':
     provider => 'appdmg',
-    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.0.4/mac/x86/LibreOffice_4.0.4_MacOS_x86.dmg'
+    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86.dmg'
   }
 }

--- a/manifests/languagepack.pp
+++ b/manifests/languagepack.pp
@@ -1,0 +1,17 @@
+# Public: Install Libreoffice.app into /Applications.
+#
+# Examples
+#
+#   include libreoffice::languagepack
+#
+#   or 
+#   
+#   class { 'libreoffice::languagepack':
+#     locale => 'de',
+#   }
+class libreoffice::languagepack ($locale = 'de') {
+  package { 'LibreOffice LanguagePack':
+    provider => 'appdmg',
+    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_${locale}.dmg'
+  }
+}

--- a/manifests/languagepack.pp
+++ b/manifests/languagepack.pp
@@ -4,14 +4,14 @@
 #
 #   include libreoffice::languagepack
 #
-#   or 
-#   
+#   or
+#
 #   class { 'libreoffice::languagepack':
 #     locale => 'de',
 #   }
 class libreoffice::languagepack ($locale = 'de') {
   package { 'LibreOffice LanguagePack':
-    provider => "appdmg",
+    provider => 'appdmg',
     source   => "http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_${locale}.dmg",
   }
 }

--- a/manifests/languagepack.pp
+++ b/manifests/languagepack.pp
@@ -11,7 +11,7 @@
 #   }
 class libreoffice::languagepack ($locale = 'de') {
   package { 'LibreOffice LanguagePack':
-    provider => 'appdmg',
-    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_${locale}.dmg'
+    provider => "appdmg",
+    source   => "http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_${locale}.dmg",
   }
 }

--- a/manifests/libreoffice
+++ b/manifests/libreoffice
@@ -1,1 +1,0 @@
-libreoffice

--- a/spec/classes/languagepack_spec.rb
+++ b/spec/classes/languagepack_spec.rb
@@ -3,23 +3,29 @@ require 'spec_helper'
 describe 'libreoffice::languagepack' do
   it do
     should contain_class('libreoffice::languagepack')
+  end
 
-    should contain_package('LibreOffice LanguagePack').with({
-      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_de.dmg',
-      :provider => 'appdmg'
-    })
+  context "default language" do
+    it do
+      should contain_package('LibreOffice LanguagePack').with({
+       :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_de.dmg',
+       :provider => 'appdmg'
+      })
+    end
+  end
 
-    context "other language" do
-      let(:params) do
+  context "other language" do
+    let(:params) do
+      {
         :locale => 'en_GB'
-      end
+      }
+    end
 
-      it do
-        should contain_package('LibreOffice LanguagePack').with({
-          :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_en_GB.dmg',
-          :provider => 'appdmg'
-        })
-      end
+    it do
+      should contain_package('LibreOffice LanguagePack').with({
+        :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_en_GB.dmg',
+        :provider => 'appdmg'
+      })
     end
   end
 end

--- a/spec/classes/languagepack_spec.rb
+++ b/spec/classes/languagepack_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'libreoffice::languagepack' do
+  it do
+    should contain_class('libreoffice::languagepack')
+
+    should contain_package('LibreOffice LanguagePack').with({
+      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_de.dmg',
+      :provider => 'appdmg'
+    })
+
+    context "other language" do
+      let(:params) do
+        :locale => 'en_GB'
+      end
+
+      it do
+        should contain_package('LibreOffice LanguagePack').with({
+          :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86_langpack_en_GB.dmg',
+          :provider => 'appdmg'
+        })
+      end
+    end
+  end
+end

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -5,7 +5,7 @@ describe 'libreoffice' do
     should contain_class('libreoffice')
 
     should contain_package('LibreOffice').with({
-      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.0_MacOS_x86.dmg',
+      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.0/mac/x86/LibreOffice_4.1.0_MacOS_x86.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -5,7 +5,7 @@ describe 'libreoffice' do
     should contain_class('libreoffice')
 
     should contain_package('LibreOffice').with({
-      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.4_MacOS_x86.dmg',
+      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.0_MacOS_x86.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -5,7 +5,7 @@ describe 'libreoffice' do
     should contain_class('libreoffice')
 
     should contain_package('LibreOffice').with({
-      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.0.4/mac/x86/LibreOffice_4.0.4_MacOS_x86.dmg',
+      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.4_MacOS_x86.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
The current stable version is 4.1.0, so I bumped the Version up.
Also there was no ability to install additional language packs, so I added a new class `libreoffice::languagepack`

Usage of the languagepack class: 

``` puppet
include libreoffice::languagepack
```

which includes the default language (German), or get your own laguage as follows:

``` puppet
class { 'libreoffice::languagepack':
  locale => 'fr',
}
```
