### PR TITLE
Update specs to LibreOffice 4.1.3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class libreoffice {
   package { 'LibreOffice':
     provider => 'appdmg',
-    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.1/mac/x86/LibreOffice_4.1.1_MacOS_x86.dmg'
+    source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.3/mac/x86/LibreOffice_4.1.3_MacOS_x86.dmg'
   }
 }

--- a/manifests/languagepack.pp
+++ b/manifests/languagepack.pp
@@ -12,6 +12,6 @@
 class libreoffice::languagepack ($locale = 'de') {
   package { 'LibreOffice LanguagePack':
     provider => 'appdmg',
-    source   => "http://download.documentfoundation.org/libreoffice/stable/4.1.1/mac/x86/LibreOffice_4.1.1_MacOS_x86_langpack_${locale}.dmg",
+    source   => "http://download.documentfoundation.org/libreoffice/stable/4.1.3/mac/x86/LibreOffice_4.1.3_MacOS_x86_langpack_${locale}.dmg",
   }
 }

--- a/spec/classes/languagepack_spec.rb
+++ b/spec/classes/languagepack_spec.rb
@@ -8,7 +8,7 @@ describe 'libreoffice::languagepack' do
   context "default language" do
     it do
       should contain_package('LibreOffice LanguagePack').with({
-       :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.1/mac/x86/LibreOffice_4.1.1_MacOS_x86_langpack_de.dmg',
+       :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.3/mac/x86/LibreOffice_4.1.3_MacOS_x86_langpack_de.dmg',
        :provider => 'appdmg'
       })
     end
@@ -23,7 +23,7 @@ describe 'libreoffice::languagepack' do
 
     it do
       should contain_package('LibreOffice LanguagePack').with({
-        :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.1/mac/x86/LibreOffice_4.1.1_MacOS_x86_langpack_en_GB.dmg',
+        :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.3/mac/x86/LibreOffice_4.1.3_MacOS_x86_langpack_en_GB.dmg',
         :provider => 'appdmg'
       })
     end

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -5,7 +5,7 @@ describe 'libreoffice' do
     should contain_class('libreoffice')
 
     should contain_package('LibreOffice').with({
-      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.1/mac/x86/LibreOffice_4.1.1_MacOS_x86.dmg',
+      :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.3/mac/x86/LibreOffice_4.1.3_MacOS_x86.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
Updated to make sure LibreOffice 4.1.3 is downloaded instead of 4.1.1. (4.1.1 isn't available anymore on the given url)
