### PR TITLE
Update to use x86-64 download path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,6 @@
 class libreoffice($version='4.2.5') {
   package { "LibreOffice-${version}":
     provider => 'appdmg',
-    source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86/LibreOffice_${version}_MacOS_x86.dmg",
+    source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86_64/LibreOffice_${version}_MacOS_x86-64.dmg",
   }
 }


### PR DESCRIPTION
This module wasn't working for me as the download file doesn't exist in the location defined in the manifest. The following worked for me, but I don't know if it will work for all combinations of version and architecture (are there different x86/x86-64 architectures available for the OSX LibreOffice packages?). 
