### PR TITLE
Update LibreOffice to 4.3.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,9 @@
 #
 #   include libreoffice
 #   class { 'libreoffice':
-#     version => '4.2.5',
+#     version => '4.3.0',
 #   }
-class libreoffice($version='4.2.5') {
+class libreoffice($version='4.3.0') {
   package { "LibreOffice-${version}":
     provider => 'appdmg',
     source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86_64/LibreOffice_${version}_MacOS_x86-64.dmg",

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'libreoffice' do
 
-  version = '4.2.5'
+  version = '4.3.0'
 
   let(:facts) do
     {


### PR DESCRIPTION
I was getting errors when trying to install LibreOffice, but updating the version numbers seems to have done the trick for me.
