### PR TITLE
Bump version and parameterize languagepack version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,9 @@
 #
 #   include libreoffice
 #   class { 'libreoffice':
-#     version => '4.2.5',
+#     version => '4.3.5',
 #   }
-class libreoffice($version='4.2.5',$fix='') {
+class libreoffice($version='4.3.5',$fix='') {
   package { "LibreOffice-${version}${fix}":
     provider => 'appdmg',
     source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86_64/LibreOffice_${version}${fix}_MacOS_x86-64.dmg",

--- a/manifests/languagepack.pp
+++ b/manifests/languagepack.pp
@@ -8,10 +8,11 @@
 #
 #   class { 'libreoffice::languagepack':
 #     locale => 'de',
+#     version => '4.3.5'
 #   }
-class libreoffice::languagepack ($locale = 'de') {
+class libreoffice::languagepack ($locale = 'de', $version = '4.3.5') {
   package { 'LibreOffice LanguagePack':
     provider => 'appdmg',
-    source   => "http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.4_MacOS_x86_langpack_${locale}.dmg",
+    source   => "http://download.documentfoundation.org/libreoffice/stable/${$version}/mac/x86/LibreOffice_${$version}_MacOS_x86_langpack_${locale}.dmg",
   }
 }

--- a/spec/classes/languagepack_spec.rb
+++ b/spec/classes/languagepack_spec.rb
@@ -1,31 +1,18 @@
 require 'spec_helper'
 
 describe 'libreoffice::languagepack' do
+  version = '4.3.5'
+  locale = 'de'
+
   it do
     should contain_class('libreoffice::languagepack')
   end
 
-  context "default language" do
-    it do
-      should contain_package('LibreOffice LanguagePack').with({
-       :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.4_MacOS_x86_langpack_de.dmg',
-       :provider => 'appdmg'
-      })
-    end
+  it do
+    should contain_package('LibreOffice LanguagePack').with({
+     :source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86/LibreOffice_${version}_MacOS_x86_langpack_${locale}.dmg",
+     :provider => "appdmg"
+    })
   end
 
-  context "other language" do
-    let(:params) do
-      {
-        :locale => 'en-GB'
-      }
-    end
-
-    it do
-      should contain_package('LibreOffice LanguagePack').with({
-        :source   => 'http://download.documentfoundation.org/libreoffice/stable/4.1.4/mac/x86/LibreOffice_4.1.4_MacOS_x86_langpack_en-GB.dmg',
-        :provider => 'appdmg'
-      })
-    end
-  end
 end

--- a/spec/classes/libreoffice_spec.rb
+++ b/spec/classes/libreoffice_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'libreoffice' do
 
   describe 'standard version' do
-    version = '4.2.5'
+    version = '4.3.5'
 
     let(:facts) do
       {
@@ -22,7 +22,7 @@ describe 'libreoffice' do
   end
 
   describe 'fixed version' do
-    version = '4.2.6'
+    version = '4.3.6'
     fix = '-secfix'
 
     let(:facts) do


### PR DESCRIPTION
In addition to bumping to version 4.3.5, this fork adds a `version` parameter on `languagepack`; without this, the main LibreOffice version is a parameter, but the languagepack version is hard-coded.
